### PR TITLE
Add navbar

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.11.0",
+    "@material-ui/icons": "^4.9.1",
     "@material-ui/styles": "^4.10.0",
     "@reduxjs/toolkit": "^1.4.0",
     "@testing-library/jest-dom": "^5.11.4",

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -12,8 +12,6 @@ function App() {
     <Router>
       <Navbar />
       <div>
-        <Link to="/create">Create Meetup</Link>
-        <Link to="/login">Login</Link>
         <Link to="/search">Search</Link>
       </div>
       <Switch>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -5,10 +5,12 @@ import Login from "./components/Login/Login";
 import Meetup from "./components/Meetup/Meetup";
 import Profile from "./components/Profile/Profile";
 import Search from "./components/Search/Search";
+import Navbar from "./components/Navbar/Navbar";
 
 function App() {
   return (
     <Router>
+      <Navbar />
       <div>
         <Link to="/create">Create Meetup</Link>
         <Link to="/login">Login</Link>

--- a/client/src/components/Navbar/Navbar.js
+++ b/client/src/components/Navbar/Navbar.js
@@ -90,7 +90,7 @@ function Navbar() {
             startIcon={<AddCircleIcon />}
             className={`${classes.button} ${classes.createButton}`}
             component={Link}
-            to={CREATE_PATH}
+            to={authenticated ? CREATE_PATH : LOGIN_PATH}
           >
             New Meetup
           </Button>

--- a/client/src/components/Navbar/Navbar.js
+++ b/client/src/components/Navbar/Navbar.js
@@ -4,11 +4,11 @@ import Box from "@material-ui/core/Box";
 import AppBar from "@material-ui/core/AppBar";
 import Toolbar from "@material-ui/core/Toolbar";
 import Typography from "@material-ui/core/Typography";
-// import Grid from '@material-ui/core/Grid';
 import Button from "@material-ui/core/Button";
-// import IconButton from '@material-ui/core/IconButton';
 import AddCircleIcon from "@material-ui/icons/AddCircle";
 import Avatar from "@material-ui/core/Avatar";
+import Menu from "@material-ui/core/Menu";
+import MenuItem from "@material-ui/core/MenuItem";
 import { makeStyles } from "@material-ui/core/styles";
 import { Link } from "react-router-dom";
 
@@ -56,10 +56,91 @@ function Navbar() {
   const classes = useStyles();
   // TODO: connect authentication
   const [authenticated, setAuthenticated] = useState(true);
+  const [profileMenuAnchor, setProfileMenuAnchor] = useState(null);
   // TODO: get profileID and avatar from user
   const profileID = 1234;
+  const profileName = "Test User";
   const profilePic =
     "http://web.cs.ucla.edu/~miryung/MiryungKimPhotoAugust2018.jpg";
+  const handleProfileMenuClick = (event) => {
+    setProfileMenuAnchor(event.currentTarget);
+  };
+
+  const handleProfileMenuClose = () => {
+    setProfileMenuAnchor(null);
+  };
+
+  const ProfileMenu = (
+    <>
+      <Button
+        startIcon={<Avatar src={profilePic} className={classes.avatar} />}
+        className={`${classes.button} ${classes.profileButton}`}
+        onClick={handleProfileMenuClick}
+      >
+        {profileName}
+      </Button>
+      <Menu
+        anchorEl={profileMenuAnchor}
+        getContentAnchorEl={null}
+        anchorOrigin={{
+          vertical: "bottom",
+          horizontal: "right",
+        }}
+        transformOrigin={{
+          vertical: "top",
+          horizontal: "right",
+        }}
+        keepMounted
+        open={Boolean(profileMenuAnchor)}
+        onClose={handleProfileMenuClose}
+      >
+        <MenuItem
+          onClick={handleProfileMenuClose}
+          component={Link}
+          to={`${PROFILE_PATH}/${profileID}`}
+        >
+          Profile
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            handleProfileMenuClose();
+            setAuthenticated(false);
+          }}
+          component={Link}
+          to="/"
+        >
+          Logout
+        </MenuItem>
+      </Menu>
+    </>
+  );
+
+  const Login = (
+    <Button
+      startIcon={<Avatar className={classes.avatar} />}
+      className={`${classes.button} ${classes.profileButton}`}
+      component={Link}
+      to={LOGIN_PATH}
+    >
+      Login
+    </Button>
+  );
+
+  const authToggle = (
+    <Button
+      size="small"
+      variant="outlined"
+      color="secondary"
+      onClick={() => {
+        setAuthenticated(!authenticated);
+      }}
+      className={classes.button}
+      component={Link}
+      to="/"
+    >
+      [DEBUG: toggle auth]
+    </Button>
+  );
 
   return (
     <Box className={classes.root}>
@@ -75,39 +156,17 @@ function Navbar() {
           >
             DownToMeet
           </Typography>
-          <Button
-            size="small"
-            variant="outlined"
-            color="secondary"
-            onClick={() => {
-              setAuthenticated(!authenticated);
-            }}
-            className={classes.button}
-          >
-            [DEBUG: toggle auth]
-          </Button>
+          {authToggle}
           <Button
             startIcon={<AddCircleIcon />}
             className={`${classes.button} ${classes.createButton}`}
             component={Link}
+            // TODO: add redirect to current path
             to={authenticated ? CREATE_PATH : LOGIN_PATH}
           >
             New Meetup
           </Button>
-          <Button
-            startIcon={
-              <Avatar
-                src={authenticated ? profilePic : null}
-                className={classes.avatar}
-              />
-            }
-            className={`${classes.button} ${classes.profileButton}`}
-            component={Link}
-            to={authenticated ? `${PROFILE_PATH}/${profileID}` : LOGIN_PATH}
-            width={100}
-          >
-            {authenticated ? "Test User" : "Login"}
-          </Button>
+          {authenticated ? ProfileMenu : Login}
         </Toolbar>
       </AppBar>
     </Box>

--- a/client/src/components/Navbar/Navbar.js
+++ b/client/src/components/Navbar/Navbar.js
@@ -1,0 +1,117 @@
+import React, { useState } from "react";
+import CssBaseline from "@material-ui/core/CssBaseline";
+import Box from "@material-ui/core/Box";
+import AppBar from "@material-ui/core/AppBar";
+import Toolbar from "@material-ui/core/Toolbar";
+import Typography from "@material-ui/core/Typography";
+// import Grid from '@material-ui/core/Grid';
+import Button from "@material-ui/core/Button";
+// import IconButton from '@material-ui/core/IconButton';
+import AddCircleIcon from "@material-ui/icons/AddCircle";
+import Avatar from "@material-ui/core/Avatar";
+import { makeStyles } from "@material-ui/core/styles";
+import { Link } from "react-router-dom";
+
+const useStyles = makeStyles(() => ({
+  // TODO: mobile scaling
+  // TODO: finalize styles (font, color)
+  // TODO: add logo?
+  root: {
+    flexGrow: 1,
+  },
+  toolbar: {
+    paddingLeft: 20,
+    paddingRight: 15,
+  },
+  button: {
+    minWidth: 100,
+    justifyContent: "left",
+    whiteSpace: "nowrap",
+    overflow: "hidden",
+    color: "white",
+    textTransform: "none",
+  },
+  createButton: {
+    margin: 5,
+  },
+  profileButton: {
+    maxWidth: "12%", // to catch long profile name
+  },
+  avatar: {
+    width: "1.5em",
+    height: "1.5em",
+  },
+  title: {
+    flexGrow: 1,
+    color: "white",
+    textDecoration: "none",
+  },
+}));
+
+const PROFILE_PATH = "/profile";
+const CREATE_PATH = "/create";
+const LOGIN_PATH = "/login";
+
+function Navbar() {
+  const classes = useStyles();
+  // TODO: connect authentication
+  const [authenticated, setAuthenticated] = useState(true);
+  // TODO: get profileID and avatar from user
+  const profileID = 1234;
+  const profilePic =
+    "http://web.cs.ucla.edu/~miryung/MiryungKimPhotoAugust2018.jpg";
+
+  return (
+    <Box className={classes.root}>
+      {/* CssBaseline clears default HTML styling (margins, etc.) */}
+      <CssBaseline />
+      <AppBar position="sticky">
+        <Toolbar className={classes.toolbar}>
+          <Typography
+            variant="h5"
+            className={classes.title}
+            component={Link}
+            to="/"
+          >
+            DownToMeet
+          </Typography>
+          <Button
+            size="small"
+            variant="outlined"
+            color="secondary"
+            onClick={() => {
+              setAuthenticated(!authenticated);
+            }}
+            className={classes.button}
+          >
+            [DEBUG: toggle auth]
+          </Button>
+          <Button
+            startIcon={<AddCircleIcon />}
+            className={`${classes.button} ${classes.createButton}`}
+            component={Link}
+            to={CREATE_PATH}
+          >
+            New Meetup
+          </Button>
+          <Button
+            startIcon={
+              <Avatar
+                src={authenticated ? profilePic : null}
+                className={classes.avatar}
+              />
+            }
+            className={`${classes.button} ${classes.profileButton}`}
+            component={Link}
+            to={authenticated ? `${PROFILE_PATH}/${profileID}` : LOGIN_PATH}
+            width={100}
+          >
+            {authenticated ? "Test User" : "Login"}
+          </Button>
+        </Toolbar>
+      </AppBar>
+    </Box>
+  );
+}
+
+export default Navbar;

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1307,6 +1307,13 @@
     react-is "^16.8.0"
     react-transition-group "^4.4.0"
 
+"@material-ui/icons@^4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-4.9.1.tgz#fdeadf8cb3d89208945b33dbc50c7c616d0bd665"
+  integrity sha512-GBitL3oBWO0hzBhvA9KxqcowRUsA0qzwKkURyC8nppnC3fw54KPKZ+d4V1Eeg/UnDRSzDaI9nGCdel/eh9AQMg==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+
 "@material-ui/styles@^4.10.0":
   version "4.10.0"
   resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.10.0.tgz#2406dc23aa358217aa8cc772e6237bd7f0544071"


### PR DESCRIPTION
Fixes: #19 

Adds (currently unstyled) navbar:
![image](https://user-images.githubusercontent.com/32582452/99548616-ce4ee200-29f3-11eb-8471-5630ee10e098.png)

- 'New meetup' button routes to `/create` if authenticated, else routes to `login`.
- Profile button routes to `/profile/:id` if authenticated, else routes to `/login`.
- DownToMeet title is clickable and routes to `/`

Placeholders used for `:id` and profile picture. Also added a temporary button to toggle authentication state (for demo purposes) until the backend is connected.