### PR TITLE
Fix search page bug

### DIFF
--- a/client/src/components/Search/Search.js
+++ b/client/src/components/Search/Search.js
@@ -45,13 +45,17 @@ function Search() {
     setMeetups(null);
     setMeetupType("");
     setSearchLocation(null);
+    setRadius("");
   };
 
   const validateSearch = () => {
     if (meetupType === "") {
       return false;
     }
-    if (meetupType === IN_PERSON && (coords === null || radius === "")) {
+    if (
+      meetupType === IN_PERSON &&
+      (searchLocation === null || radius === "")
+    ) {
       return false;
     }
     return true;
@@ -65,8 +69,8 @@ function Search() {
     setError(false);
     if (meetupType === IN_PERSON) {
       const { res, resJSON } = await fetcher.searchForMeetups({
-        lat: coords[0],
-        lon: coords[1],
+        lat: searchLocation.coords[0],
+        lon: searchLocation.coords[1],
         radius,
         tags,
       });


### PR DESCRIPTION
Was originally using `coords` to check if the form was properly filled out, but `coords` is populated by the "Use GPS" button. This PR changes the validation to use `searchLocation`, which is the value in the location search bar.